### PR TITLE
shell: use the correct nodejs package for node_modules and the shell

### DIFF
--- a/internal.nix
+++ b/internal.nix
@@ -109,7 +109,7 @@ rec {
       nm = node_modules attrs;
     in
     mkShell {
-      buildInputs = [ nodejs ];
+      buildInputs = [ nm.nodejs ];
       shellHook = ''
         export NODE_PATH="${nm}/node_modules:$NODE_PATH"
       '';

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -10,4 +10,5 @@ in
   make-source-urls = callPackage ./make-source-urls.nix {};
   patch-lockfile = callPackage ./patch-lockfile.nix {};
   node-modules = callPackage ./node-modules.nix {};
+  shell = callPackage ./shell.nix {};
 }

--- a/tests/shell.nix
+++ b/tests/shell.nix
@@ -1,0 +1,26 @@
+{ npmlock2nix, testLib, symlinkJoin, runCommand, nodejs }:
+testLib.runTests {
+  # test that the shell expression uses the same (given) nodejs package for
+  # both the shell and node_modules
+  testUsesGivenNodeJSPackage =
+    let
+      custom_nodejs = symlinkJoin {
+        name = "custom-nodejs";
+        paths = [ nodejs ];
+      };
+      drv = npmlock2nix.shell {
+        src = ./examples-projects/single-dependency;
+        nodejs = custom_nodejs;
+      };
+    in
+    {
+      expr = {
+        inherit(drv) buildInputs;
+        node_modules_nodejs = drv.node_modules.nodejs;
+      };
+      expected = {
+        buildInputs = [ custom_nodejs ];
+        node_modules_nodejs = custom_nodejs;
+      };
+    };
+}


### PR DESCRIPTION
To make most out of the shell expression is it sensible to use the same
NodeJS package that was used for building the modules in the shell.