### PR TITLE
Use bats for integration tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,5 +15,5 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: cachix/install-nix-action@v10
-      - run: ./integration-tests/leftpad-shell.sh
+      - run: ./integration-tests/tests.sh
 

--- a/integration-tests/leftpad-shell.sh
+++ b/integration-tests/leftpad-shell.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-
-nix-shell $DIR/../tests/examples-projects/single-dependency/shell.nix --run "node -e 'require(\"leftpad\")(123, 7);'"

--- a/integration-tests/tests.sh
+++ b/integration-tests/tests.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -p bats -i bats
+
+@test "Require a node dependency inside the shell environment" {
+    run nix-shell ./tests/examples-projects/single-dependency/shell.nix --run "node -e 'console.log(require(\"leftpad\")(123, 7));'"
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "0000123" ]
+}
+
+@test "Set the nodejs version to use to v10 inside the shell environment" {
+    run nix-shell ./tests/examples-projects/single-dependency/shell.nix --argstr version "10_x" --run "node -e 'console.log(process.version.split(\".\")[0]);'"
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "v10" ]
+}

--- a/internal.nix
+++ b/internal.nix
@@ -93,7 +93,6 @@ rec {
       '';
       installPhase = ''
         mkdir $out
-        set -x
         if test -d node_modules; then
           mv node_modules $out/
         fi
@@ -109,7 +108,7 @@ rec {
       nm = node_modules attrs;
     in
     mkShell {
-      buildInputs = [ nodejs ];
+      buildInputs = [ nm.passthru.nodejs ];
       shellHook = ''
         export NODE_PATH="${nm}/node_modules:$NODE_PATH"
       '';

--- a/tests/examples-projects/single-dependency/shell.nix
+++ b/tests/examples-projects/single-dependency/shell.nix
@@ -1,4 +1,5 @@
-{ pkgs ? import ../../../nix }:
+{ pkgs ? import ../../../nix, version ? "12_x"}:
 pkgs.npmlock2nix.shell {
   src = ./.;
+  nodejs = pkgs."nodejs-${version}";
 }


### PR DESCRIPTION
This introduces the use of https://github.com/sstephenson/bats to
execute the integration tests.

This also drops a `-x` that was still in there and fixes the shell expression to actually use the nodejs version when one has been specified.