### PR TITLE
Use smoke

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -5,6 +5,7 @@ in import sources.nixpkgs {
   overlays = [
     (self: super: {
       npmlock2nix = self.callPackage ../default.nix {};
+      inherit (self.callPackage (import sources.smoke) {}) smoke;
     })
   ];
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -10,5 +10,17 @@
         "type": "tarball",
         "url": "https://github.com/NixOS/nixpkgs-channels/archive/5717d9d2f7ca0662291910c52f1d7b95b568fec2.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
+    "smoke": {
+        "branch": "master",
+        "description": "Runs tests against anything, using command-line arguments, STDIN, STDOUT and STDERR.",
+        "homepage": "",
+        "owner": "SamirTalwar",
+        "repo": "smoke",
+        "rev": "a80cba28744e93b9b0564a1155deb504ea650114",
+        "sha256": "10b09z1ay7adr2bar2xv8ph13j8gvz7xm5rkhclgqk7d2ccc0j1n",
+        "type": "tarball",
+        "url": "https://github.com/SamirTalwar/smoke/archive/a80cba28744e93b9b0564a1155deb504ea650114.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,10 +1,10 @@
 let
-  pkgs = import ./nix;
+  pkgs = import ./nix {};
 
   test-runner = pkgs.writeScriptBin "test-runner" ''
     find . -type f | ${pkgs.entr}/bin/entr -c nix-build -A tests --show-trace
   '';
 
 in pkgs.mkShell {
-  buildInputs = [ test-runner pkgs.nodejs ];
+  buildInputs = [ test-runner pkgs.nodejs pkgs.smoke ];
 }

--- a/tests/examples-projects/nodejs-version-shell/package-lock.json
+++ b/tests/examples-projects/nodejs-version-shell/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "single-dependency",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "leftpad": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/leftpad/-/leftpad-0.0.1.tgz",
+      "integrity": "sha1-hrGk3k+s4YCsVFqD8VA1I9j+0RU="
+    }
+  }
+}

--- a/tests/examples-projects/nodejs-version-shell/package.json
+++ b/tests/examples-projects/nodejs-version-shell/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "single-dependency",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "leftpad": "0.0.1"
+  }
+}

--- a/tests/examples-projects/nodejs-version-shell/shell.nix
+++ b/tests/examples-projects/nodejs-version-shell/shell.nix
@@ -1,0 +1,9 @@
+{ pkgs ? import ../../../nix {} }:
+let
+  node = pkgs.nodejs-10_x;
+in
+assert pkgs.nodejs == node -> throw "default nodejs version has been updated. Please update the test";
+pkgs.npmlock2nix.shell {
+  src = ./.;
+  nodejs = node;
+}

--- a/tests/examples-projects/nodejs-version-shell/shell.nix
+++ b/tests/examples-projects/nodejs-version-shell/shell.nix
@@ -2,7 +2,10 @@
 let
   node = pkgs.nodejs-10_x;
 in
-assert pkgs.nodejs == node -> throw "default nodejs version has been updated. Please update the test";
+# We need make sure that `nodejs` does not default to `nodejs-10_x` because
+# then our test cannot ensure that we can override the default. If the assert
+# below throws, change `node` above to a different version.
+assert pkgs.nodejs == node -> throw "`nodejs` is refering to `nodejs-10_x` rendering this test ineffective.";
 pkgs.npmlock2nix.shell {
   src = ./.;
   nodejs = node;

--- a/tests/examples-projects/single-dependency/shell.nix
+++ b/tests/examples-projects/single-dependency/shell.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import ../../../nix }:
+{ pkgs ? import ../../../nix {} }:
 pkgs.npmlock2nix.shell {
   src = ./.;
 }

--- a/tests/integration-tests/default.nix
+++ b/tests/integration-tests/default.nix
@@ -6,6 +6,14 @@ testLib.makeIntegrationTests {
     command = ''
       node -e 'console.log(require("leftpad")(123, 7));'
     '';
-    expected = "0000123";
+    expected = "0000123\n";
+  };
+  nodejsVersion = {
+    description = "Specify nodejs version to use";
+    shell = import ../examples-projects/nodejs-version-shell/shell.nix {};
+    command = ''
+      node -e 'console.log(process.versions.node.split(".")[0]);'
+    '';
+    expected = "10\n";
   };
 }


### PR DESCRIPTION
This replaces `bats` with [Smoke](https://github.com/SamirTalwar/Smoke). While bats "worked" assertion errors would not produce any output at all making it impossible to effectively debug failures at all.