### PR TITLE
Do not patch bundled dependencies

### DIFF
--- a/internal.nix
+++ b/internal.nix
@@ -40,9 +40,12 @@ rec {
   patchDependency = name: spec:
     assert (builtins.typeOf name != "string") -> builtins.throw "Name of dependency ${toString name} must be a string";
     assert (builtins.typeOf spec != "set") -> builtins.throw "Spec of dependency ${toString name} must be a set";
-    spec // {
+    let
+      isBundled = spec ? bundled && spec.bundled == true;
+    in
+    spec // lib.optionalAttrs (!isBundled) ({
       resolved = "file://" + (toString (makeSource name spec));
-    } // lib.optionalAttrs (spec ? dependencies) {
+    }) // lib.optionalAttrs (spec ? dependencies) {
       dependencies = lib.mapAttrs patchDependency spec.dependencies;
     };
 

--- a/tests/patch-lockfile.nix
+++ b/tests/patch-lockfile.nix
@@ -1,6 +1,21 @@
 { npmlock2nix, testLib, lib }:
 testLib.runTests {
 
+  testBundledDependenciesAreRetained = {
+    expr = npmlock2nix.internal.patchDependency "test" {
+      bundled = true;
+      integrity = "sha1-hrGk3k+s4YCsVFqD8VA1I9j+0RU=";
+      something = "bar";
+      dependencies = { };
+    };
+    expected = {
+      bundled = true;
+      integrity = "sha1-hrGk3k+s4YCsVFqD8VA1I9j+0RU=";
+      something = "bar";
+      dependencies = { };
+    };
+  };
+
   testPatchLockfileWithoutDependencies = {
     expr = (npmlock2nix.internal.patchLockfile ./examples-projects/no-dependencies/package-lock.json).dependencies;
     expected = { };


### PR DESCRIPTION
Whenever a dependency has `bundled` set to true, then we don't update the resolved/integrity attributes.