### PR TITLE
Expose node_modules/.bin as $out/bin

### DIFF
--- a/internal.nix
+++ b/internal.nix
@@ -95,6 +95,9 @@ rec {
         mkdir $out
         if test -d node_modules; then
           mv node_modules $out/
+          if test -d $out/node_modules/.bin; then
+            ln -s $out/node_modules/.bin $out/bin
+          fi
         fi
       '';
 
@@ -108,7 +111,7 @@ rec {
       nm = node_modules attrs;
     in
     mkShell {
-      buildInputs = [ nm.nodejs ];
+      buildInputs = [ nm.nodejs nm ];
       shellHook = ''
         export NODE_PATH="${nm}/node_modules:$NODE_PATH"
       '';

--- a/tests/examples-projects/bin-project/index.js
+++ b/tests/examples-projects/bin-project/index.js
@@ -1,0 +1,1 @@
+console.log("hello world");

--- a/tests/examples-projects/bin-project/package-lock.json
+++ b/tests/examples-projects/bin-project/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "bin-project",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+    }
+  }
+}

--- a/tests/examples-projects/bin-project/package.json
+++ b/tests/examples-projects/bin-project/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "bin-project",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "mkdirp": "^1.0.4"
+  }
+}

--- a/tests/examples-projects/bin-project/shell.nix
+++ b/tests/examples-projects/bin-project/shell.nix
@@ -1,0 +1,12 @@
+{ pkgs ? import ../../../nix { } }:
+let
+  node = pkgs.nodejs-10_x;
+in
+# We need make sure that `nodejs` does not default to `nodejs-10_x` because
+  # then our test cannot ensure that we can override the default. If the assert
+  # below throws, change `node` above to a different version.
+assert pkgs.nodejs == node -> throw "`nodejs` is refering to `nodejs-10_x` rendering this test ineffective.";
+pkgs.npmlock2nix.shell {
+  src = ./.;
+  nodejs = node;
+}

--- a/tests/integration-tests/default.nix
+++ b/tests/integration-tests/default.nix
@@ -16,4 +16,12 @@ testLib.makeIntegrationTests {
     '';
     expected = "10\n";
   };
+  pathContainsNodeApplications = {
+    description = "Applications from the node_modules/.bin folder should be available on $PATH in the shell expression";
+    shell = npmlock2nix.shell { src = ../examples-projects/bin-project; };
+    command = ''
+      mkdirp --version
+    '';
+    expected = "1.0.4\n";
+  };
 }

--- a/tests/shell.nix
+++ b/tests/shell.nix
@@ -19,7 +19,7 @@ testLib.runTests {
         node_modules_nodejs = drv.node_modules.nodejs;
       };
       expected = {
-        buildInputs = [ custom_nodejs ];
+        buildInputs = [ custom_nodejs drv.node_modules ];
         node_modules_nodejs = custom_nodejs;
       };
     };


### PR DESCRIPTION
Exposing node_modules binaries from `.bin` in the $out output of
the node_modules package makes them conevenient to use as buildInputs