### PR TITLE
Add cachix to the CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,10 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: cachix/install-nix-action@v10
+      - uses: cachix/cachix-action@v6
+        with:
+          name: npmlock2nix
+          signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
       - run: |
           nix-shell --run "nixpkgs-fmt --check ."
           ./test.sh


### PR DESCRIPTION
This adds a binary cache for all our build artifacts. Hopefully, this
speeds up subsequent builds on CI as they are rather slow right now.