### PR TITLE
Ensure the shell.nix in the root of the project works

### DIFF
--- a/tests/integration-tests/default.nix
+++ b/tests/integration-tests/default.nix
@@ -1,5 +1,19 @@
 { npmlock2nix, testLib }:
 testLib.makeIntegrationTests {
+
+  shell = {
+    description = "Require this projects shell expression to work";
+    shell = import ../../shell.nix;
+    command = ''
+      type -a test-runner > /dev/null
+      type -a node > /dev/null
+      type -a smoke > /dev/null
+      type -a niv > /dev/null
+      type -a nixpkgs-fmt > /dev/null
+    '';
+    expected = "";
+  };
+
   leftpad = {
     description = "Require a node dependency inside the shell environment";
     shell = npmlock2nix.shell { src = ../examples-projects/single-dependency; };


### PR DESCRIPTION
By making the shell.nix part of our integration tests we can ensure that the shell keeps on working when we change things in the repo.