### PR TITLE
tests/testPatchedLockFile: use the output hash of a file instead the …

### DIFF
--- a/tests/lib.nix
+++ b/tests/lib.nix
@@ -5,6 +5,9 @@
 , smoke
 , coreutils
 }: {
+  # Reads a given file (either drv, path or string) and returns it's sha256 hash
+  hashFile = filename: builtins.hashString "sha256" (builtins.readFile filename);
+
   runTests = tests:
     let
       failures = lib.debug.runTests tests;

--- a/tests/patch-lockfile.nix
+++ b/tests/patch-lockfile.nix
@@ -77,8 +77,8 @@ testLib.runTests {
   };
 
   testPatchedLockFile = {
-    expr = toString (npmlock2nix.internal.patchedLockfile ./examples-projects/nested-dependencies/package-lock.json);
-    expected = "/nix/store/b0iqhx5kaa20qm4ra7j4wr5ggmlkhbn0-packages-lock.json";
+    expr = testLib.hashFile (npmlock2nix.internal.patchedLockfile ./examples-projects/nested-dependencies/package-lock.json);
+    expected = "980323c3a53d86ab6886f21882936cfe7c06ac633993f16431d79e3185084414";
   };
 
 }


### PR DESCRIPTION
…store path

The store path depends on all the build inputs (e.g. CC version in the stdenv). By using the output hash the test will not fail when we update nixpkgs unless it is a real breakage