### PR TITLE
Shell link node modules

### DIFF
--- a/tests/integration-tests/default.nix
+++ b/tests/integration-tests/default.nix
@@ -24,4 +24,44 @@ testLib.makeIntegrationTests {
     '';
     expected = "1.0.4\n";
   };
+
+  symlinkNodeModules =
+    let
+      shell = npmlock2nix.shell { src = ../examples-projects/bin-project; symlink_node_modules = true; };
+    in
+    {
+      description = ''
+        The shell builder supports linking the nix build node_modules folder into
+        the current working directory via the `shellHook`. Verify taht we are
+        indeed doing that.
+      '';
+      inherit shell;
+      command = ''
+        readlink -f node_modules
+      '';
+      expected = toString (shell.node_modules + "/node_modules\n");
+    };
+
+  symlinkNodeModulesDoesNotOverrideExistingNodeModules =
+    let
+      shell = npmlock2nix.shell { src = ../examples-projects/bin-project; symlink_node_modules = true; };
+    in
+    {
+      description = ''
+        Ensure the shellHook doesn't override node_modules directory.
+      '';
+      inherit shell;
+      setup-command = ''
+        mkdir node_modules
+      '';
+      command = ''
+        readlink -f node_modules
+      '';
+      status = 1;
+      expected = "";
+      expected-stderr = ''
+        [npmlock2nix] There is already a `node_modules` directory. Not replacing it.
+      '';
+    };
+
 }

--- a/tests/lib.nix
+++ b/tests/lib.nix
@@ -27,6 +27,7 @@
   # , shell
   # , command
   # , expected
+  # , (optional) expected-stderr
   # , (optional) status
   # , (optional) temporary-directory = true
   # , (optional) setup-command
@@ -60,6 +61,8 @@
           command = test.script;
           stdout = test.expected;
           exit-status = test.status or 0;
+        } // lib.optionalAttrs (test ? expected-stderr) {
+          stderr = test.expected-stderr;
         })
         (lib.attrValues testScripts);
 

--- a/tests/lib.nix
+++ b/tests/lib.nix
@@ -20,8 +20,17 @@
     if builtins.length failures == 0 then [ ] else
     builtins.throw msg;
 
-  # Takes an attribute set of tests { description, shell, command, expected, (optional) status, (optional) temporary-directory = true }
+  # Takes an attribute set of tests
   # an creates a bats script that executes them.
+  # Each tests set has this format:
+  # { description
+  # , shell
+  # , command
+  # , expected
+  # , (optional) status
+  # , (optional) temporary-directory = true
+  # , (optional) setup-command
+  # }
   makeIntegrationTests = tests:
     let
       mkTestScript = name: test:
@@ -40,6 +49,7 @@
             trap cleanup EXIT
             cd $WORKING_DIR
           ''}
+          ${lib.optionalString (test ? setup-command) test.setup-command}
           nix-shell --pure ${shellDrv} --run "${writeShellScript "${name}-command" test.command}"
         '';
       testScripts = lib.mapAttrs (name: test: test // { script = mkTestScript name test; inherit name; }) tests;

--- a/tests/lib.nix
+++ b/tests/lib.nix
@@ -20,18 +20,29 @@
     if builtins.length failures == 0 then [ ] else
     builtins.throw msg;
 
-  # Takes an attribute set of tests { description, shell, command, expected, (optional) status }
+  # Takes an attribute set of tests { description, shell, command, expected, (optional) status, (optional) temporary-directory = true }
   # an creates a bats script that executes them.
   makeIntegrationTests = tests:
     let
-      mkTestScript = name: shell: command:
+      mkTestScript = name: test:
         let
-          shellDrv = (shell.overrideAttrs (_: { phases = [ "noopPhase" ]; noopPhase = "touch $out"; })).drvPath; in
+          shellDrv = (test.shell.overrideAttrs (_: { phases = [ "noopPhase" ]; noopPhase = "touch $out"; })).drvPath;
+          temporaryDirectory = test.temporary-directory or true;
+        in
         writeShellScript name ''
           export PATH="${nix}/bin:${coreutils}/bin"
-          exec nix-shell --pure ${shellDrv} --run "${writeShellScript "${name}-command" command}"
+          set -e
+          ${lib.optionalString temporaryDirectory ''
+            WORKING_DIR=$(mktemp -d)
+            function cleanup {
+              rm -rf "$WORKING_DIR"
+            }
+            trap cleanup EXIT
+            cd $WORKING_DIR
+          ''}
+          nix-shell --pure ${shellDrv} --run "${writeShellScript "${name}-command" test.command}"
         '';
-      testScripts = lib.mapAttrs (name: test: test // { script = mkTestScript name test.shell test.command; inherit name; }) tests;
+      testScripts = lib.mapAttrs (name: test: test // { script = mkTestScript name test; inherit name; }) tests;
 
       smokeConfig.tests = map
         (test: {


### PR DESCRIPTION
This adds support for linking the generated `node_modules` folder into the current working directory when the shell is being started. The `shellHook` will do it's best to not destory data. It will error out if there is already a `node_modules` **directory** in the current folder.