### PR TITLE
Split the CI test command in two run statements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,5 @@ jobs:
         with:
           name: npmlock2nix
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
-      - run: |
-          nix-shell --run "nixpkgs-fmt --check ."
-          ./test.sh
+      - run: nix-shell --run "nixpkgs-fmt --check ."
+      - run: ./test.sh


### PR DESCRIPTION
Previously the formatting test as well as the actual test execution
would happen in the same step. The GitHub UI only shows us the first
line of the command. By splitting them into two individual steps the
output on the GH Actions UI should be much nicer.