### PR TITLE
throw an error when github: sources are used in the lockfile

### DIFF
--- a/internal.nix
+++ b/internal.nix
@@ -43,11 +43,14 @@ rec {
     let
       isBundled = spec ? bundled && spec.bundled == true;
     in
-    spec // lib.optionalAttrs (!isBundled) ({
-      resolved = "file://" + (toString (makeSource name spec));
-    }) // lib.optionalAttrs (spec ? dependencies) {
-      dependencies = lib.mapAttrs patchDependency spec.dependencies;
-    };
+    if lib.hasPrefix "github:" (spec.from or "") || lib.hasPrefix "github:" (spec.source or "") then
+      throw "[npmlock2nix] The given package-lock.json contains sources that refer to GitHub. The source spec is often not precise enough to be translated into a (reliable) Nix git fetch invocation."
+    else
+      (spec // lib.optionalAttrs (!isBundled) ({
+        resolved = "file://" + (toString (makeSource name spec));
+      }) // lib.optionalAttrs (spec ? dependencies) {
+        dependencies = lib.mapAttrs patchDependency spec.dependencies;
+      });
 
   # Description: Takes a Path to a lockfile and returns the patched version as attribute set
   # Type: Path -> Set

--- a/tests/examples-projects/github-dependency/package-lock.json
+++ b/tests/examples-projects/github-dependency/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "github-dependency",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "leftpad": {
+      "version": "github:tmcw/leftpad#db1442a0556c2b133627ffebf455a78a1ced64b9",
+      "from": "github:tmcw/leftpad"
+    }
+  }
+}

--- a/tests/examples-projects/github-dependency/package.json
+++ b/tests/examples-projects/github-dependency/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "github-dependency",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "leftpad": "github:tmcw/leftpad"
+  }
+}

--- a/tests/integration-tests/default.nix
+++ b/tests/integration-tests/default.nix
@@ -187,4 +187,22 @@ testLib.makeIntegrationTests {
       ${libwebp}/bin/cwebp
     '';
   };
+  warnAboutGithubDependencies = {
+    description = ''
+      Ensure that we warn about github: dependencies and abort the eval if they are encoutered.
+    '';
+    evalFailure = true;
+    shell = npmlock2nix.shell {
+      src = ../examples-projects/github-dependency;
+    };
+    command = ''
+      exit 123
+    '';
+    status = 1;
+    expected = "";
+    expected-stderr = ''
+      error: [npmlock2nix] The given package-lock.json contains sources that refer to GitHub. The source spec is often not precise enough to be translated into a (reliable) Nix git fetch invocation.
+      (use '--show-trace' to show detailed location information)
+    '';
+  };
 }


### PR DESCRIPTION
We are currently unable to fetch github: sources in a variety of cases.
Often the sources do not properly specify the source branch (or tag) but
just refer to a short-rev that is then expanded into a "long" rev in the
lockfile. To use `builtins.fetchGit` we must know the proper ref (e.g. a
branch) to fetch that revision from.