### PR TITLE
Node modules support extra args

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ npmlock2nix.node_modules {
   #       "vendor/cweb-bin" = "${pkgs.libwebp}/bin/cwebp"
   #   };
   # };
+
+  # You can set any desired environment by just adding them to this set just
+  # like you would do in a regular `stdenv.mkDerivation` invocation:
+  # MY_ENVIRONMENT_VARIABLE = "foo";
 }
 ```
 

--- a/internal.nix
+++ b/internal.nix
@@ -146,8 +146,10 @@ rec {
           '';
           executable = true;
         };
+
+        extraArgs = builtins.removeAttrs args [ "preInstallLinks" ];
       in
-      stdenv.mkDerivation {
+      stdenv.mkDerivation (extraArgs // {
         inherit (lockfile) version;
         pname = lockfile.name;
         inherit src buildInputs preBuild postBuild;
@@ -198,7 +200,7 @@ rec {
         passthru = {
           inherit nodejs;
         };
-      };
+      });
 
   shell =
     { node_modules_mode ? "symlink"

--- a/internal.nix
+++ b/internal.nix
@@ -139,7 +139,7 @@ rec {
               )}
 
             if grep -I -q -r '/bin/' .; then
-              source $stdenv/setup
+              source $TMP/preinstall-env
               patchShebangs .
             fi
 
@@ -175,6 +175,7 @@ rec {
         buildPhase = ''
           runHook preBuild
           mkdir -p node_modules/.hooks
+          declare -pf > $TMP/preinstall-env
           ln -s ${preinstall_node_modules}/node_modules/.hooks/prepare node_modules/.hooks/preinstall
           npm install --offline --nodedir=${nodeSource nodejs}
           test -d node_modules/.bin && patchShebangs node_modules/.bin

--- a/tests/node-modules.nix
+++ b/tests/node-modules.nix
@@ -111,4 +111,11 @@ testLib.runTests {
       expected = true;
     };
 
+  testPassesExtraParameters = {
+    expr = (npmlock2nix.node_modules {
+      src = ./examples-projects/single-dependency;
+      SOME_EXTRA_PARAMETER = "123";
+    }).SOME_EXTRA_PARAMETER or "attribute missing";
+    expected = "123";
+  };
 }


### PR DESCRIPTION
his allows users to add parameters to the mkDerivation call. One common
use-case is setting environment variables that some of the node packages
might accept.

While working on this I also optimized the `preinstall` hook a bit since it can be an annoyingly long process with larger projects. The change included in this PR removes 60% of the build time in my test project.