### PR TITLE
node_modules: filter the `src` attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,15 @@ npmlock2nix.node_modules {
   # You can set any desired environment by just adding them to this set just
   # like you would do in a regular `stdenv.mkDerivation` invocation:
   # MY_ENVIRONMENT_VARIABLE = "foo";
+
+  # By default all sources are being filtered for just the relevant bits (e.g.
+  # the `package.json`) so the chances for false-positive rebuilds are minimal.
+  # If, for whatever reason, you have to turn the source filtering off you can just set:
+  # filterSource = false;
+
+  # If you instead want another source filter function, you can set the
+  # `sourceFilter` attribute to a function taking `src` as the first argument:
+  # sourceFilter = src: lib.cleanSourceWith { filter = name: type: …; inherit src; };
 }
 ```
 

--- a/tests/lib.nix
+++ b/tests/lib.nix
@@ -98,7 +98,8 @@
     '';
 
   withoutNodeModules = src: lib.cleanSourceWith {
-    filter = name: type: ! (type == "directory" && name == "node_modules");
+    filter = name: type:
+      let basename = baseNameOf name; in ! (type == "directory" && basename == "node_modules");
     inherit src;
   };
 }

--- a/tests/node-modules.nix
+++ b/tests/node-modules.nix
@@ -118,4 +118,45 @@ testLib.runTests {
     }).SOME_EXTRA_PARAMETER or "attribute missing";
     expected = "123";
   };
+
+  testFiltersSourcesForJustPackageJson = {
+    expr = builtins.readFile ((npmlock2nix.node_modules {
+      src = ./examples-projects/single-dependency;
+
+      postBuild = ''
+        set -ex
+        if [ -e shell.nix ]; then
+          echo "The shell.nix file should have been remove due to source filtering"
+          exit 1;
+        fi
+
+        echo filtered-source > node_modules/test
+
+      '';
+    }) + "/node_modules/test");
+    expected = ''
+      filtered-source
+    '';
+  };
+
+  testFiltersSourcesDisabled = {
+    expr = builtins.readFile ((npmlock2nix.node_modules {
+      src = ./examples-projects/single-dependency;
+      filterSource = false;
+
+      postBuild = ''
+        set -ex
+        if [ ! -e shell.nix ]; then
+          echo "The shell.nix file should *NOT* have been remove due to source filtering"
+          exit 1;
+        fi
+
+        echo unfiltered-source > node_modules/test
+
+      '';
+    }) + "/node_modules/test");
+    expected = ''
+      unfiltered-source
+    '';
+  };
 }


### PR DESCRIPTION
Very often we can install all the node packages without any of the stuff
in the source tree. The only relevant pieces are the `package-lock.json`
and the `package.json`. By default we will now throw away all files
except the `package.json`.

This also adds a `filterSource` boolean that allows opt-out of the
source filtering - if that is deisred. We also allow the users to
provide another filter function (name `sourceFilter`) to customize the
filtering.