### PR TITLE
Make sure the right nixpkgs-fmt version is used

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -7,6 +7,9 @@ let
 
   pre-commit-hooks = pkgs.nix-pre-commit-hooks.run {
     src = ./.;
+    tools = {
+      nixpkgs-fmt = pkgs.nixpkgs-fmt;
+    };
     hooks = {
       nixpkgs-fmt.enable = true;
     };


### PR DESCRIPTION
This ensures that the version used in the hook is identical to the one
added to the shell environment (I just ran into a situation where this
was not the case and hook and shell version disagreed about formatting
because of the version gap).