### PR TITLE
shell: Fix some UX annoyances

### DIFF
--- a/internal.nix
+++ b/internal.nix
@@ -398,7 +398,7 @@ rec {
     }@attrs:
     let
       nm = node_modules (get_node_modules_attrs attrs);
-      extraAttrs = builtins.removeAttrs attrs [ "node_modules_attrs" "passthru" ];
+      extraAttrs = builtins.removeAttrs attrs [ "node_modules_attrs" "passthru" "buildInputs" ];
     in
     stdenv.mkDerivation ({
       pname = nm.pname;

--- a/internal.nix
+++ b/internal.nix
@@ -374,7 +374,7 @@ rec {
     }@attrs:
     let
       nm = node_modules (get_node_modules_attrs attrs);
-      extraAttrs = builtins.removeAttrs attrs [ "node_modules_attrs" "passthru" "shellHook" ];
+      extraAttrs = builtins.removeAttrs attrs [ "node_modules_attrs" "passthru" "shellHook" "buildInputs" ];
     in
     mkShell ({
       buildInputs = buildInputs ++ [ nm.nodejs nm ];

--- a/internal.nix
+++ b/internal.nix
@@ -366,7 +366,7 @@ rec {
       extraAttrs = builtins.removeAttrs attrs [ "node_modules_attrs" ];
     in
     mkShell ({
-      buildInputs = [ nm.nodejs nm ];
+      buildInputs = attrs.buildInputs or [ ] ++ [ nm.nodejs nm ];
       shellHook = ''
         # If node_modules is a managed symlink we can safely remove it and install a new one
         ${lib.optionalString (node_modules_mode == "symlink") ''

--- a/internal.nix
+++ b/internal.nix
@@ -359,6 +359,8 @@ rec {
 
   shell =
     { node_modules_mode ? "symlink"
+    , buildInputs ? [ ]
+    , passthru ? { }
     , ...
     }@attrs:
     let
@@ -366,7 +368,7 @@ rec {
       extraAttrs = builtins.removeAttrs attrs [ "node_modules_attrs" ];
     in
     mkShell ({
-      buildInputs = attrs.buildInputs or [ ] ++ [ nm.nodejs nm ];
+      buildInputs = buildInputs ++ [ nm.nodejs nm ];
       shellHook = ''
         # If node_modules is a managed symlink we can safely remove it and install a new one
         ${lib.optionalString (node_modules_mode == "symlink") ''
@@ -378,7 +380,9 @@ rec {
         # FIXME: we should somehow register a GC root here in case of a symlink?
         ${add_node_modules_to_cwd nm node_modules_mode}
       '';
-      passthru.node_modules = nm;
+      passthru = passthru // {
+        node_modules = nm;
+      };
     } // extraAttrs);
 
   build =

--- a/internal.nix
+++ b/internal.nix
@@ -374,7 +374,7 @@ rec {
     }@attrs:
     let
       nm = node_modules (get_node_modules_attrs attrs);
-      extraAttrs = builtins.removeAttrs attrs [ "node_modules_attrs" "passthru" ];
+      extraAttrs = builtins.removeAttrs attrs [ "node_modules_attrs" "passthru" "shellHook" ];
     in
     mkShell ({
       buildInputs = buildInputs ++ [ nm.nodejs nm ];

--- a/internal.nix
+++ b/internal.nix
@@ -361,6 +361,7 @@ rec {
     { node_modules_mode ? "symlink"
     , buildInputs ? [ ]
     , passthru ? { }
+    , shellHook ? ""
     , ...
     }@attrs:
     let
@@ -379,7 +380,7 @@ rec {
 
         # FIXME: we should somehow register a GC root here in case of a symlink?
         ${add_node_modules_to_cwd nm node_modules_mode}
-      '';
+      '' + shellHook;
       passthru = passthru // {
         node_modules = nm;
       };

--- a/internal.nix
+++ b/internal.nix
@@ -262,6 +262,7 @@ rec {
     , postBuild ? ""
     , preInstallLinks ? { } # set that describes which files should be linked in a specific packages folder
     , githubSourceHashMap ? { }
+    , passthru ? { }
     , ...
     }@args:
       assert (builtins.typeOf preInstallLinks != "set") ->
@@ -357,7 +358,7 @@ rec {
           fi
         '';
 
-        passthru = {
+        passthru = passthru // {
           inherit nodejs;
           lockfile = patchedLockfile packageLockJson;
           packagesfile = patchedPackagefile packageJson;
@@ -373,7 +374,7 @@ rec {
     }@attrs:
     let
       nm = node_modules (get_node_modules_attrs attrs);
-      extraAttrs = builtins.removeAttrs attrs [ "node_modules_attrs" ];
+      extraAttrs = builtins.removeAttrs attrs [ "node_modules_attrs" "passthru" ];
     in
     mkShell ({
       buildInputs = buildInputs ++ [ nm.nodejs nm ];
@@ -392,11 +393,12 @@ rec {
     , installPhase
     , node_modules_mode ? "symlink"
     , buildInputs ? [ ]
+    , passthru ? { }
     , ...
     }@attrs:
     let
       nm = node_modules (get_node_modules_attrs attrs);
-      extraAttrs = builtins.removeAttrs attrs [ "node_modules_attrs" ];
+      extraAttrs = builtins.removeAttrs attrs [ "node_modules_attrs" "passthru" ];
     in
     stdenv.mkDerivation ({
       pname = nm.pname;
@@ -412,6 +414,6 @@ rec {
         runHook postBuild
       '';
 
-      passthru.node_modules = nm;
+      passthru = passthru // { node_modules = nm; };
     } // extraAttrs);
 }

--- a/internal.nix
+++ b/internal.nix
@@ -368,6 +368,13 @@ rec {
     mkShell ({
       buildInputs = [ nm.nodejs nm ];
       shellHook = ''
+        # If node_modules is a managed symlink we can safely remove it and install a new one
+        ${lib.optionalString (node_modules_mode == "symlink") ''
+          if [[ "$(readlink -f node_modules)" == ${builtins.storeDir}* ]]; then
+            rm -f node_modules
+          fi
+        ''}
+
         # FIXME: we should somehow register a GC root here in case of a symlink?
         ${add_node_modules_to_cwd nm node_modules_mode}
       '';

--- a/tests/build-tests.nix
+++ b/tests/build-tests.nix
@@ -1,4 +1,4 @@
-{ lib, symlinkJoin, npmlock2nix, runCommand, libwebp }:
+{ lib, symlinkJoin, npmlock2nix, runCommand, libwebp, python3 }:
 let
   symlinkAttrs = attrs: runCommand "symlink-attrs"
     { }
@@ -52,4 +52,12 @@ symlinkAttrs {
     };
   };
 
+  passsing-buildInputs-doesnt-break-the-build = npmlock2nix.build {
+    src = ./examples-projects/webpack-cli-project;
+    installPhase = ''
+      cp -r dist $out
+    '';
+
+    buildInputs = [ python3 ];
+  };
 }

--- a/tests/build.nix
+++ b/tests/build.nix
@@ -1,0 +1,24 @@
+{ npmlock2nix, testLib }:
+testLib.runTests {
+  testPassthruIsHonored =
+    let
+      drv = npmlock2nix.build {
+        src = ./examples-projects/single-dependency;
+        installPhase = "
+          # should never run as we only test eval here
+          exit 123
+        ";
+        passthru.test-attr = 123;
+      };
+    in
+    {
+      expr = {
+        inherit (drv.passthru) test-attr;
+        has_node_modules = drv.passthru ? node_modules;
+      };
+      expected = {
+        test-attr = 123;
+        has_node_modules = true;
+      };
+    };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -16,5 +16,6 @@ in
   shell = callPackage ./shell.nix { };
   integration-tests = callPackage ./integration-tests { };
   build-tests = callPackage ./build-tests.nix { };
+  build = callPackage ./build.nix { };
   source-hash-func = callPackage ./source-hash-func.nix { };
 }

--- a/tests/integration-tests/default.nix
+++ b/tests/integration-tests/default.nix
@@ -1,4 +1,4 @@
-{ npmlock2nix, testLib, callPackage, libwebp, runCommandNoCC }:
+{ npmlock2nix, testLib, callPackage, libwebp, runCommandNoCC, python3 }:
 testLib.makeIntegrationTests {
   leftpad = {
     description = "Require a node dependency inside the shell environment";
@@ -158,6 +158,24 @@ testLib.makeIntegrationTests {
       expected = "";
     };
 
+  buildInputsDoesntRemoveDefaultValues =
+    let
+      shell = npmlock2nix.shell {
+        src = ../examples-projects/bin-project;
+        buildInputs = [ python3 ];
+      };
+    in
+    {
+      description = ''
+        Ensure that providing additional buildInputs doesn't break our default buildInputs (e.g. nodejs).
+      '';
+      inherit shell;
+      command = ''
+        node --version > /dev/null || exit 1
+        python3 --version > /dev/null || exit 1
+      '';
+      expected = "";
+    };
 
   webpackCli = {
     description = ''

--- a/tests/node-modules.nix
+++ b/tests/node-modules.nix
@@ -118,4 +118,12 @@ testLib.runTests {
     }).SOME_EXTRA_PARAMETER or "attribute missing";
     expected = "123";
   };
+
+  testHonorsPassedPassthru = {
+    expr = (npmlock2nix.node_modules {
+      src = ./examples-projects/single-dependency;
+      passthru.test-param = 123;
+    }).passthru.test-param;
+    expected = 123;
+  };
 }

--- a/tests/shell.nix
+++ b/tests/shell.nix
@@ -51,4 +51,22 @@ testLib.runTests {
       expected = "foobar in postBuild";
     };
 
+  testPassthruIsHonored =
+    let
+      drv = npmlock2nix.shell {
+        src = ./examples-projects/single-dependency;
+        passthru.test-attribute = 123;
+      };
+    in
+    {
+      expr = {
+        inherit (drv.passthru) test-attribute;
+        has_node_modules = drv.passthru ? node_modules;
+      };
+      expected = {
+        test-attribute = 123;
+        has_node_modules = true;
+      };
+    };
+
 }

--- a/tests/shell.nix
+++ b/tests/shell.nix
@@ -1,4 +1,4 @@
-{ npmlock2nix, testLib, symlinkJoin, runCommand, nodejs }:
+{ npmlock2nix, testLib, symlinkJoin, runCommand, nodejs, lib }:
 testLib.runTests {
   # test that the shell expression uses the same (given) nodejs package for
   # both the shell and node_modules
@@ -66,6 +66,30 @@ testLib.runTests {
       expected = {
         test-attribute = 123;
         has_node_modules = true;
+      };
+    };
+
+  testShellHookIsHonored =
+    let
+      drv = npmlock2nix.shell {
+        src = ./examples-projects/single-dependency;
+        shellHook = "magic-string";
+      };
+    in
+    {
+      # the shellHook should now contain a bunch of lines (for setting up the node_modules symlink / copy) and the given line. Our line must be on a line of its own.
+      expr =
+        let
+          lines = lib.splitString "\n" drv.shellHook;
+          more_than_one_line = (builtins.length lines) > 1;
+          last_line = builtins.head (lib.reverseList lines);
+        in
+        {
+          inherit more_than_one_line last_line;
+        };
+      expected = {
+        more_than_one_line = true;
+        last_line = "magic-string";
       };
     };
 


### PR DESCRIPTION
This PR adds two minor changes:
- Removes existing node_modules symlink if it is a Nix store path (fixes #50)
- Respects explicitly passed attributes like `buildInputs`, `passthru` & `shellHook`