### PR TITLE
Restricted mode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,13 @@ rebuilding the project (with the same dependencies) quicker.
 npmlock2nix.node_modules {
   src = ./.;
   # buildInputs = [ … ];
-
+  # If you want to use npmlock2nix in restricted evaluation mode (e.g hydra)
+  # you need to specify the hashes for the projects you want to use in a
+  # githubSourceHashMap as shown below (You can also pass this through
+  # via 'node_modules_attrs' in the `npmlock2nix.build`).
+  # githubSourceHashMap = {
+  #  someuser.somerepo."<rev>" = "<hash>";
+  # };
   # You can symlink files into the directory of a specific dependency using the
   # preInstallLinks attribute. Below you see how you can create a link to the
   # cwebp binary at `node_modules/cwebp-bin/cwebp`.

--- a/internal.nix
+++ b/internal.nix
@@ -40,12 +40,14 @@ rec {
   buildTgzFromGitHub = { name, org, repo, rev, ref, hash ? null }:
     let
       src =
-        if hash != null then fetchFromGitHub {
-          owner = org;
-          inherit repo;
-          inherit rev;
-          sha256 = hash; # FIXME: what if sha3?
-        } else
+        if hash != null then
+          fetchFromGitHub
+            {
+              owner = org;
+              inherit repo;
+              inherit rev;
+              sha256 = hash; # FIXME: what if sha3?
+            } else
           builtins.fetchGit {
             url = "https://github.com/${org}/${repo}";
             inherit rev ref;

--- a/internal.nix
+++ b/internal.nix
@@ -1,4 +1,4 @@
-{ nodejs, stdenv, mkShell, lib, fetchurl, writeText, writeTextFile, runCommand }:
+{ nodejs, stdenv, mkShell, lib, fetchurl, writeText, writeTextFile, runCommand, fetchFromGitHub }:
 rec {
   default_nodejs = nodejs;
 
@@ -35,12 +35,19 @@ rec {
   # Description: Takes an attribute set describing a git dependency and returns
   # a .tgz of the repository as store path
   # Type: Set -> Path
-  buildTgzFromGitHub = { name, org, repo, rev, ref }:
+  buildTgzFromGitHub = { name, org, repo, rev, ref, hash ? null }:
     let
-      src = builtins.fetchGit {
-        url = "https://github.com/${org}/${repo}";
-        inherit rev ref;
-      };
+      src =
+        if hash != null then fetchFromGitHub {
+          owner = org;
+          inherit repo;
+          inherit rev;
+          sha256 = hash; # FIXME: what if sha3?
+        } else
+          builtins.fetchGit {
+            url = "https://github.com/${org}/${repo}";
+            inherit rev ref;
+          };
     in
     runCommand
       name
@@ -52,7 +59,7 @@ rec {
   # Description: Turns a dependency with a from field of the format
   # `github:org/repo#revision` into a git fetcher
   # Type: String -> Set -> Path
-  makeGithubSource = name: dependency:
+  makeGithubSource = sourceHashFunc: name: dependency:
     assert !(dependency ? version) ->
       builtins.throw "Missing `version` attribute missing from `${name}`";
     assert (lib.hasPrefix "github: " dependency.version) -> builtins.throw "invalid prefix for `version` field of `${name}` expected `github:`, got: `${dependency.version}`.";
@@ -67,6 +74,7 @@ rec {
         name = "${name}.tgz";
         ref = v.rev;
         inherit (v) org repo rev;
+        hash = sourceHashFunc { type = "github"; value = v; };
       };
     in
     (builtins.removeAttrs dependency [ "from" ]) // {
@@ -75,7 +83,7 @@ rec {
 
   # Description: Turns an npm lockfile dependency into a fetchurl derivation
   # Type: String -> Set -> Derivation
-  makeSource = name: dependency:
+  makeSource = name: dependency: sourceHashFunc:
     assert (builtins.typeOf name != "string") ->
       throw "[npmlock2nix] Name of dependency ${toString name} must be a string";
     assert (builtins.typeOf dependency != "set") ->
@@ -83,7 +91,7 @@ rec {
     if dependency ? resolved && dependency ? integrity then
       dependency // { resolved = "file://" + (toString (fetchurl (makeSourceAttrs name dependency))); }
     else if dependency ? from && dependency ? version then
-      makeGithubSource name dependency
+      makeGithubSource sourceHashFunc name dependency
     else throw "[npmlock2nix] A valid dependency consists of at least the resolved and integrity field. Missing one or both of them for `${name}`. The object I got looks like this: ${builtins.toJSON dependency}";
 
   # Description: Parses the lock file as json and returns an attribute set
@@ -102,7 +110,7 @@ rec {
 
   # Description: Turns a github string reference into a store path with a tgz of the reference
   # Type: String -> String -> Path
-  stringToTgzPath = name: str:
+  stringToTgzPath = sourceHashFunc: name: str:
     let
       gitAttrs = parseGitHubRef str;
     in
@@ -110,20 +118,21 @@ rec {
       name = "${name}.tgz";
       ref = gitAttrs.rev;
       inherit (gitAttrs) org repo rev;
+      hash = sourceHashFunc { type = "github"; value = gitAttrs; };
     };
 
   # Description: Patch the `requires` attributes of a dependency spec to refer to paths in the store
   # Type: String -> Set -> Set
-  patchRequires = name: requires:
+  patchRequires = sourceHashFunc: name: requires:
     let
-      patchReq = name: version: if lib.hasPrefix "github:" version then stringToTgzPath name version else version;
+      patchReq = name: version: if lib.hasPrefix "github:" version then stringToTgzPath sourceHashFunc name version else version;
     in
     lib.mapAttrs patchReq requires;
 
 
   # Description: Patches a single lockfile dependency (recursively) by replacing the resolved URL with a store path
   # Type: String -> Set -> Set
-  patchDependency = name: spec:
+  patchDependency = sourceHashFunc: name: spec:
     assert (builtins.typeOf name != "string") ->
       throw "[npmlock2nix] Name of dependency ${toString name} must be a string";
     assert (builtins.typeOf spec != "set") ->
@@ -131,9 +140,9 @@ rec {
     let
       isBundled = spec ? bundled && spec.bundled == true;
       hasGitHubRequires = spec: (spec ? requires) && (lib.any (x: lib.hasPrefix "github:" x) (lib.attrValues spec.requires));
-      patchSource = lib.optionalAttrs (!isBundled) (makeSource name spec);
-      patchRequiresSources = lib.optionalAttrs (hasGitHubRequires spec) { requires = (patchRequires name spec.requires); };
-      patchDependenciesSources = lib.optionalAttrs (spec ? dependencies) { dependencies = lib.mapAttrs patchDependency spec.dependencies; };
+      patchSource = lib.optionalAttrs (!isBundled) (makeSource name spec sourceHashFunc);
+      patchRequiresSources = lib.optionalAttrs (hasGitHubRequires spec) { requires = (patchRequires sourceHashFunc name spec.requires); };
+      patchDependenciesSources = lib.optionalAttrs (spec ? dependencies) { dependencies = lib.mapAttrs (patchDependency sourceHashFunc) spec.dependencies; };
     in
     # For our purposes we need a dependency with
       # - `resolved` set to a path in the nix store (`patchSource`)
@@ -143,17 +152,17 @@ rec {
 
   # Description: Takes a Path to a lockfile and returns the patched version as attribute set
   # Type: Path -> Set
-  patchLockfile = file:
+  patchLockfile = sourceHashFunc: file:
     assert (builtins.typeOf file != "path" && builtins.typeOf file != "string") ->
       throw "[npmlock2nix] file ${toString file} must be a path or string";
     let content = readLockfile file; in
     content // {
-      dependencies = lib.mapAttrs patchDependency content.dependencies;
+      dependencies = lib.mapAttrs (patchDependency sourceHashFunc) content.dependencies;
     };
 
   # Description: Rewrite all the `github:` references to store paths
   # Type: Path -> Set
-  patchPackagefile = file:
+  patchPackagefile = sourceHashFunc: file:
     assert (builtins.typeOf file != "path" && builtins.typeOf file != "string") ->
       throw "[npmlock2nix] file ${toString file} must be a path or string";
     let
@@ -162,7 +171,7 @@ rec {
       content = builtins.fromJSON (builtins.readFile file);
       patchDep = (name: version:
         if lib.hasPrefix "github:" version then
-          "file://${stringToTgzPath name version}"
+          "file://${stringToTgzPath sourceHashFunc name version}"
         else version);
       dependencies = if (content ? dependencies) then lib.mapAttrs patchDep content.dependencies else { };
       devDependencies = if (content ? devDependencies) then lib.mapAttrs patchDep content.devDependencies else { };
@@ -171,15 +180,15 @@ rec {
 
   # Description: Takes a Path to a package file and returns the patched version as file in the Nix store
   # Type: Path -> Derivation
-  patchedPackagefile = file: writeText "package.json"
+  patchedPackagefile = sourceHashFunc: file: writeText "package.json"
     (
-      builtins.toJSON (patchPackagefile file)
+      builtins.toJSON (patchPackagefile sourceHashFunc file)
     );
 
   # Description: Takes a Path to a lockfile and returns the patched version as file in the Nix store
   # Type: Path -> Derivation
-  patchedLockfile = file: writeText "packages-lock.json"
-    (builtins.toJSON (patchLockfile file));
+  patchedLockfile = sourceHashFunc: file: writeText "packages-lock.json"
+    (builtins.toJSON (patchLockfile sourceHashFunc file));
 
   # Description: Turn a derivation (with name & src attribute) into a directory containing the unpacked sources
   # Type: Derivation -> Derivation
@@ -231,12 +240,13 @@ rec {
     , preBuild ? ""
     , postBuild ? ""
     , preInstallLinks ? { } # set that describes which files should be linked in a specific packages folder
+    , githubSourceHashMap ? { }
     , ...
     }@args:
       assert (builtins.typeOf preInstallLinks != "set") ->
         throw "[npmlock2nix] `preInstallLinks` must be an attributeset of attributesets";
       let
-        cleanArgs = builtins.removeAttrs args [ "src" "packageJson" "packageLockJson" "buildInputs" "nativeBuildInputs" "nodejs" "preBuild" "postBuild" "preInstallLinks" ];
+        cleanArgs = builtins.removeAttrs args [ "src" "packageJson" "packageLockJson" "buildInputs" "nativeBuildInputs" "nodejs" "preBuild" "postBuild" "preInstallLinks" "githubSourceHashMap" ];
         lockfile = readLockfile packageLockJson;
 
         preinstall_node_modules = writeTextFile {
@@ -274,6 +284,11 @@ rec {
             '';
           executable = true;
         };
+
+        sourceHashFunc = spec:
+          if spec.type == "github" then
+            lib.attrByPath [ spec.value.org spec.value.repo spec.value.rev ] null githubSourceHashMap
+          else null;
       in
       stdenv.mkDerivation ({
         inherit (lockfile) version;
@@ -297,8 +312,8 @@ rec {
         '';
 
         postPatch = ''
-          ln -sf ${patchedLockfile packageLockJson} package-lock.json
-          ln -sf ${patchedPackagefile packageJson} package.json
+          ln -sf ${patchedLockfile sourceHashFunc packageLockJson} package-lock.json
+          ln -sf ${patchedPackagefile sourceHashFunc packageJson} package.json
         '';
 
         buildPhase = ''

--- a/internal.nix
+++ b/internal.nix
@@ -241,7 +241,8 @@ rec {
   sourceHashFunc = githubSourceHashMap: spec:
     if spec.type == "github" then
       lib.attrByPath [ spec.value.org spec.value.repo spec.value.rev ] null githubSourceHashMap
-    else null;
+    else
+      throw "[npmlock2nix] sourceHashFunc: spec.type '${spec.type}' is not supported. Supported types: 'github'";
 
   node_modules =
     { src

--- a/test.sh
+++ b/test.sh
@@ -12,4 +12,4 @@ echo -e "\n\nRunning integration tests\n"
 $(nix-build  -A tests.integration-tests --no-out-link --show-trace)
 
 echo -e "\n\nTest githubSourceHashMap in restricted mode\n"
-nix-build tests/examples-projects/github-dependency/default.nix --restrict-eval -I . --allowed-uris 'https://github.com/NixOS/nixpkgs-channels' --show-trace
+nix-build tests/examples-projects/github-dependency/default.nix --restrict-eval -I . --allowed-uris 'https://github.com/nixos/nixpkgs' --show-trace

--- a/test.sh
+++ b/test.sh
@@ -6,7 +6,10 @@ set -e
 export XDG_CONFIG_HOME="/foo/bar"
 
 echo -e "Running unit tests\n"
-nix-build -A tests --no-build-output --no-out-link
+nix-build -A tests --no-build-output --no-out-link --show-trace
 
 echo -e "\n\nRunning integration tests\n"
-$(nix-build  -A tests.integration-tests --no-out-link)
+$(nix-build  -A tests.integration-tests --no-out-link --show-trace)
+
+echo -e "\n\nTest githubSourceHashMap in restricted mode\n"
+nix-build tests/examples-projects/github-dependency/default.nix --restrict-eval -I . --allowed-uris 'https://github.com/NixOS/nixpkgs-channels' --show-trace

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -16,4 +16,5 @@ in
   shell = callPackage ./shell.nix { };
   integration-tests = callPackage ./integration-tests { };
   build-tests = callPackage ./build-tests.nix { };
+  source-hash-func = callPackage ./source-hash-func.nix { };
 }

--- a/tests/examples-projects/github-dependency/default.nix
+++ b/tests/examples-projects/github-dependency/default.nix
@@ -1,0 +1,10 @@
+{ pkgs ? import ../../../nix { } }:
+
+pkgs.npmlock2nix.node_modules {
+  src = ./.;
+  packageJson = ./package.json;
+  packageLockJson = ./package-lock.json;
+  githubSourceHashMap = {
+    tmcw.leftpad.db1442a0556c2b133627ffebf455a78a1ced64b9 = "1zyy1nxbby4wcl30rc8fsis1c3f7nafavnwd3qi4bg0x00gxjdnh";
+  };
+}

--- a/tests/lib.nix
+++ b/tests/lib.nix
@@ -10,6 +10,8 @@
   # Reads a given file (either drv, path or string) and returns it's sha256 hash
   hashFile = filename: builtins.hashString "sha256" (builtins.readFile filename);
 
+  noGithubHashes = (_: null);
+
   runTests = tests:
     let
       failures = lib.debug.runTests tests;

--- a/tests/make-github-source.nix
+++ b/tests/make-github-source.nix
@@ -11,7 +11,7 @@ in
   testSimpleCase = {
     expr =
       let
-        version = (i.makeGithubSource "leftpad" testDependency).version;
+        version = (i.makeGithubSource (_: null) "leftpad" testDependency).version;
       in
       lib.hasPrefix "file:///nix/store" version;
     expected = true;
@@ -20,7 +20,7 @@ in
   testDropsFrom = {
     expr =
       let
-        dep = i.makeGithubSource "leftpad" testDependency;
+        dep = i.makeGithubSource (_: null) "leftpad" testDependency;
       in
       dep ? from;
     expected = false;

--- a/tests/make-github-source.nix
+++ b/tests/make-github-source.nix
@@ -1,5 +1,6 @@
 { lib, npmlock2nix, testLib }:
 let
+  inherit (testLib) noGithubHashes;
   i = npmlock2nix.internal;
 
   testDependency = {
@@ -11,7 +12,7 @@ in
   testSimpleCase = {
     expr =
       let
-        version = (i.makeGithubSource (_: null) "leftpad" testDependency).version;
+        version = (i.makeGithubSource noGithubHashes "leftpad" testDependency).version;
       in
       lib.hasPrefix "file:///nix/store" version;
     expected = true;
@@ -20,7 +21,7 @@ in
   testDropsFrom = {
     expr =
       let
-        dep = i.makeGithubSource (_: null) "leftpad" testDependency;
+        dep = i.makeGithubSource noGithubHashes "leftpad" testDependency;
       in
       dep ? from;
     expected = false;

--- a/tests/patch-lockfile.nix
+++ b/tests/patch-lockfile.nix
@@ -4,7 +4,7 @@ testLib.runTests {
   testPatchDependencyHandlesGitHubRefsInRequires = {
     expr =
       let
-        libxmljsUrl = (npmlock2nix.internal.patchDependency "test" {
+        libxmljsUrl = (npmlock2nix.internal.patchDependency (_: null) "test" {
           version = "github:tmcw/leftpad#db1442a0556c2b133627ffebf455a78a1ced64b9";
           from = "github:tmcw/leftpad#db1442a0556c2b133627ffebf455a78a1ced64b9";
           integrity = "sha512-8/UvHFG90J4O4QNRzb0jB5Ni1QuvuB7XFTLfDMQnCzAsFemF29VKnNGUESFFcSP/r5WWh/PMe0YRz90+3IqsUA==";
@@ -19,7 +19,7 @@ testLib.runTests {
   };
 
   testBundledDependenciesAreRetained = {
-    expr = npmlock2nix.internal.patchDependency "test" {
+    expr = npmlock2nix.internal.patchDependency (_: null) "test" {
       bundled = true;
       integrity = "sha1-hrGk3k+s4YCsVFqD8VA1I9j+0RU=";
       something = "bar";
@@ -34,12 +34,12 @@ testLib.runTests {
   };
 
   testPatchLockfileWithoutDependencies = {
-    expr = (npmlock2nix.internal.patchLockfile ./examples-projects/no-dependencies/package-lock.json).dependencies;
+    expr = (npmlock2nix.internal.patchLockfile (_: null) ./examples-projects/no-dependencies/package-lock.json).dependencies;
     expected = { };
   };
 
   testPatchDependencyDoesntDropAttributes = {
-    expr = npmlock2nix.internal.patchDependency "test" {
+    expr = npmlock2nix.internal.patchDependency (_: null) "test" {
       a = 1;
       foo = "something";
       resolved = "https://examples.com/something.tgz";
@@ -56,7 +56,7 @@ testLib.runTests {
   };
 
   testPatchDependencyPatchesDependenciesRecursively = {
-    expr = npmlock2nix.internal.patchDependency "test" {
+    expr = npmlock2nix.internal.patchDependency (_: null) "test" {
       a = 1;
       foo = "something";
       resolved = "https://examples.com/something.tgz";
@@ -82,7 +82,7 @@ testLib.runTests {
   testPatchLockfileTurnsUrlsIntoStorePaths = {
     expr =
       let
-        deps = (npmlock2nix.internal.patchLockfile ./examples-projects/single-dependency/package-lock.json).dependencies;
+        deps = (npmlock2nix.internal.patchLockfile (_: null) ./examples-projects/single-dependency/package-lock.json).dependencies;
       in
       lib.count (dep: lib.hasPrefix "file:///nix/store/" dep.resolved) (lib.attrValues deps);
     expected = 1;
@@ -91,19 +91,19 @@ testLib.runTests {
   testPatchLockfileTurnsGitHubUrlsIntoStorePaths = {
     expr =
       let
-        leftpad = (npmlock2nix.internal.patchLockfile ./examples-projects/github-dependency/package-lock.json).dependencies.leftpad;
+        leftpad = (npmlock2nix.internal.patchLockfile (_: null) ./examples-projects/github-dependency/package-lock.json).dependencies.leftpad;
       in
       lib.hasPrefix ("file://" + builtins.storeDir) leftpad.version;
     expected = true;
   };
 
   testConvertPatchedLockfileToJSON = {
-    expr = builtins.typeOf (builtins.toJSON (npmlock2nix.internal.patchLockfile ./examples-projects/nested-dependencies/package-lock.json)) == "string";
+    expr = builtins.typeOf (builtins.toJSON (npmlock2nix.internal.patchLockfile (_: null) ./examples-projects/nested-dependencies/package-lock.json)) == "string";
     expected = true;
   };
 
   testPatchedLockFile = {
-    expr = testLib.hashFile (npmlock2nix.internal.patchedLockfile ./examples-projects/nested-dependencies/package-lock.json);
+    expr = testLib.hashFile (npmlock2nix.internal.patchedLockfile (_: null) ./examples-projects/nested-dependencies/package-lock.json);
     expected = "980323c3a53d86ab6886f21882936cfe7c06ac633993f16431d79e3185084414";
   };
 

--- a/tests/patch-lockfile.nix
+++ b/tests/patch-lockfile.nix
@@ -1,10 +1,13 @@
 { npmlock2nix, testLib, lib }:
+let
+  inherit (testLib) noGithubHashes;
+in
 testLib.runTests {
 
   testPatchDependencyHandlesGitHubRefsInRequires = {
     expr =
       let
-        libxmljsUrl = (npmlock2nix.internal.patchDependency (_: null) "test" {
+        libxmljsUrl = (npmlock2nix.internal.patchDependency noGithubHashes "test" {
           version = "github:tmcw/leftpad#db1442a0556c2b133627ffebf455a78a1ced64b9";
           from = "github:tmcw/leftpad#db1442a0556c2b133627ffebf455a78a1ced64b9";
           integrity = "sha512-8/UvHFG90J4O4QNRzb0jB5Ni1QuvuB7XFTLfDMQnCzAsFemF29VKnNGUESFFcSP/r5WWh/PMe0YRz90+3IqsUA==";
@@ -19,7 +22,7 @@ testLib.runTests {
   };
 
   testBundledDependenciesAreRetained = {
-    expr = npmlock2nix.internal.patchDependency (_: null) "test" {
+    expr = npmlock2nix.internal.patchDependency noGithubHashes "test" {
       bundled = true;
       integrity = "sha1-hrGk3k+s4YCsVFqD8VA1I9j+0RU=";
       something = "bar";
@@ -34,12 +37,12 @@ testLib.runTests {
   };
 
   testPatchLockfileWithoutDependencies = {
-    expr = (npmlock2nix.internal.patchLockfile (_: null) ./examples-projects/no-dependencies/package-lock.json).dependencies;
+    expr = (npmlock2nix.internal.patchLockfile noGithubHashes ./examples-projects/no-dependencies/package-lock.json).dependencies;
     expected = { };
   };
 
   testPatchDependencyDoesntDropAttributes = {
-    expr = npmlock2nix.internal.patchDependency (_: null) "test" {
+    expr = npmlock2nix.internal.patchDependency noGithubHashes "test" {
       a = 1;
       foo = "something";
       resolved = "https://examples.com/something.tgz";
@@ -56,7 +59,7 @@ testLib.runTests {
   };
 
   testPatchDependencyPatchesDependenciesRecursively = {
-    expr = npmlock2nix.internal.patchDependency (_: null) "test" {
+    expr = npmlock2nix.internal.patchDependency noGithubHashes "test" {
       a = 1;
       foo = "something";
       resolved = "https://examples.com/something.tgz";
@@ -82,7 +85,7 @@ testLib.runTests {
   testPatchLockfileTurnsUrlsIntoStorePaths = {
     expr =
       let
-        deps = (npmlock2nix.internal.patchLockfile (_: null) ./examples-projects/single-dependency/package-lock.json).dependencies;
+        deps = (npmlock2nix.internal.patchLockfile noGithubHashes ./examples-projects/single-dependency/package-lock.json).dependencies;
       in
       lib.count (dep: lib.hasPrefix "file:///nix/store/" dep.resolved) (lib.attrValues deps);
     expected = 1;
@@ -91,19 +94,19 @@ testLib.runTests {
   testPatchLockfileTurnsGitHubUrlsIntoStorePaths = {
     expr =
       let
-        leftpad = (npmlock2nix.internal.patchLockfile (_: null) ./examples-projects/github-dependency/package-lock.json).dependencies.leftpad;
+        leftpad = (npmlock2nix.internal.patchLockfile noGithubHashes ./examples-projects/github-dependency/package-lock.json).dependencies.leftpad;
       in
       lib.hasPrefix ("file://" + builtins.storeDir) leftpad.version;
     expected = true;
   };
 
   testConvertPatchedLockfileToJSON = {
-    expr = builtins.typeOf (builtins.toJSON (npmlock2nix.internal.patchLockfile (_: null) ./examples-projects/nested-dependencies/package-lock.json)) == "string";
+    expr = builtins.typeOf (builtins.toJSON (npmlock2nix.internal.patchLockfile noGithubHashes ./examples-projects/nested-dependencies/package-lock.json)) == "string";
     expected = true;
   };
 
   testPatchedLockFile = {
-    expr = testLib.hashFile (npmlock2nix.internal.patchedLockfile (_: null) ./examples-projects/nested-dependencies/package-lock.json);
+    expr = testLib.hashFile (npmlock2nix.internal.patchedLockfile noGithubHashes ./examples-projects/nested-dependencies/package-lock.json);
     expected = "980323c3a53d86ab6886f21882936cfe7c06ac633993f16431d79e3185084414";
   };
 

--- a/tests/patch-packagefile.nix
+++ b/tests/patch-packagefile.nix
@@ -1,12 +1,13 @@
 { lib, npmlock2nix, testLib }:
 let
+  inherit (testLib) noGithubHashes;
   i = npmlock2nix.internal;
 in
 (testLib.runTests {
   testTurnsGitHubRefsToStorePaths = {
     expr =
       let
-        leftpad = (npmlock2nix.internal.patchPackagefile (_: null) ./examples-projects/github-dependency/package.json).dependencies.leftpad;
+        leftpad = (npmlock2nix.internal.patchPackagefile noGithubHashes ./examples-projects/github-dependency/package.json).dependencies.leftpad;
       in
       lib.hasPrefix ("file://" + builtins.storeDir) leftpad;
     expected = true;
@@ -14,7 +15,7 @@ in
   testHandlesDevDependencies = {
     expr =
       let
-        leftpad = (npmlock2nix.internal.patchPackagefile (_: null) ./examples-projects/github-dev-dependency/package.json).devDependencies.leftpad;
+        leftpad = (npmlock2nix.internal.patchPackagefile noGithubHashes ./examples-projects/github-dev-dependency/package.json).devDependencies.leftpad;
       in
       lib.hasPrefix ("file://" + builtins.storeDir) leftpad;
     expected = true;

--- a/tests/patch-packagefile.nix
+++ b/tests/patch-packagefile.nix
@@ -6,7 +6,7 @@ in
   testTurnsGitHubRefsToStorePaths = {
     expr =
       let
-        leftpad = (npmlock2nix.internal.patchPackagefile ./examples-projects/github-dependency/package.json).dependencies.leftpad;
+        leftpad = (npmlock2nix.internal.patchPackagefile (_: null) ./examples-projects/github-dependency/package.json).dependencies.leftpad;
       in
       lib.hasPrefix ("file://" + builtins.storeDir) leftpad;
     expected = true;
@@ -14,7 +14,7 @@ in
   testHandlesDevDependencies = {
     expr =
       let
-        leftpad = (npmlock2nix.internal.patchPackagefile ./examples-projects/github-dev-dependency/package.json).devDependencies.leftpad;
+        leftpad = (npmlock2nix.internal.patchPackagefile (_: null) ./examples-projects/github-dev-dependency/package.json).devDependencies.leftpad;
       in
       lib.hasPrefix ("file://" + builtins.storeDir) leftpad;
     expected = true;

--- a/tests/source-hash-func.nix
+++ b/tests/source-hash-func.nix
@@ -1,0 +1,22 @@
+{ lib, npmlock2nix, testLib }:
+let
+  i = npmlock2nix.internal;
+
+  testGitHubMap = {
+    foo-org.foo-repo."db1442a0556c2b133627ffebf455a78a1ced64b9" = "github-repo-hash";
+  };
+  testSpec = {
+    type = "github";
+    value = {
+      org = "foo-org";
+      repo = "foo-repo";
+      rev = "db1442a0556c2b133627ffebf455a78a1ced64b9";
+    };
+  };
+in
+(testLib.runTests {
+  testSimpleCase = {
+    expr = i.sourceHashFunc testGitHubMap testSpec;
+    expected = "github-repo-hash";
+  };
+})


### PR DESCRIPTION
This PR introduces support for GitHub dependencies in restricted mode by accepting a map of GitHub dependency identifiers and respective dependencies:

```nix
pkgs.npmlock2nix.node_modules {  
  src = ./.;
  packageJson = ./package.json;
  packageLockJson = ./package-lock.json;
  githubSourceHashMap = { 
    tmcw.leftpad.db1442a0556c2b133627ffebf455a78a1ced64b9 = "1zyy1nxbby4wcl30rc8fsis1c3f7nafavnwd3qi4bg0x00gxjdnh";  
  };
}
```

In `buildTgzFromGitHub` either `fetchFromGitHub` is called using the hash provided from the map above, or it defaults to `builtins.fetchGit` - which only works in non-restricted mode.