### PR TITLE
node_modules: do not inherit all of `src`

### DIFF
--- a/internal.nix
+++ b/internal.nix
@@ -303,7 +303,8 @@ rec {
       stdenv.mkDerivation ({
         inherit (lockfile) version;
         pname = lockfile.name;
-        inherit src buildInputs preBuild postBuild;
+        inherit buildInputs preBuild postBuild;
+        dontUnpack = true;
 
         nativeBuildInputs = nativeBuildInputs ++ [
           nodejs


### PR DESCRIPTION
Previosuly we would depend on `src` whe building the node_modules folder
despite not actually depending on it (except for the package.json and
package-lock.json).

This fixes #77