### PR TITLE
fix: convert the npm name to a nix name

### DIFF
--- a/internal.nix
+++ b/internal.nix
@@ -15,6 +15,19 @@ rec {
       hash = dependency.integrity;
     };
 
+  # Description: Returns true if the given input character is allowed within a derviation name.
+  # Type: String -> Boolean
+  # Source: https://github.com/nixos/nix/blob/706777a4a8b13771221f9b0ef3e984a50562e82b/src/libstore/path.cc#L5-L17
+  isValidDrvNameChar = c:
+    "0" <= c && c <= "9" ||
+    "a" <= c && c <= "z" ||
+    "A" <= c && c <= "Z" ||
+    c == "+" || c == "-" || c == "." || c == "_" || c == "?" || c == "=";
+
+  # Description: Converts a npm package name to something that is compatible with nix
+  # Type: String -> String
+  makeValidDrvName = str:
+    lib.stringAsChars (c: if isValidDrvNameChar c then c else "?") str;
 
   # Description: Takes a string of the format "github:org/repo#revision" and returns
   # an attribute set { org, repo, rev }
@@ -310,7 +323,7 @@ rec {
       in
       stdenv.mkDerivation ({
         inherit (lockfile) version;
-        pname = lockfile.name;
+        pname = makeValidDrvName lockfile.name;
         inherit buildInputs preBuild postBuild;
         dontUnpack = true;
 

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -6,16 +6,16 @@ let
   };
 in
 {
+  build = callPackage ./build.nix { };
+  build-tests = callPackage ./build-tests.nix { };
+  integration-tests = callPackage ./integration-tests { };
   make-github-source = callPackage ./make-github-source.nix { };
-  parse-github-ref = callPackage ./parse-github-ref.nix { };
-  read-lockfile = callPackage ./read-lockfile { };
   make-source-urls = callPackage ./make-source-urls.nix { };
+  node-modules = callPackage ./node-modules.nix { };
+  parse-github-ref = callPackage ./parse-github-ref.nix { };
   patch-lockfile = callPackage ./patch-lockfile.nix { };
   patch-packagefile = callPackage ./patch-packagefile.nix { };
-  node-modules = callPackage ./node-modules.nix { };
+  read-lockfile = callPackage ./read-lockfile { };
   shell = callPackage ./shell.nix { };
-  integration-tests = callPackage ./integration-tests { };
-  build-tests = callPackage ./build-tests.nix { };
-  build = callPackage ./build.nix { };
   source-hash-func = callPackage ./source-hash-func.nix { };
 }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -16,6 +16,7 @@ in
   patch-lockfile = callPackage ./patch-lockfile.nix { };
   patch-packagefile = callPackage ./patch-packagefile.nix { };
   read-lockfile = callPackage ./read-lockfile { };
+  sanitize-package-names = callPackage ./sanitize-package-names.nix { };
   shell = callPackage ./shell.nix { };
   source-hash-func = callPackage ./source-hash-func.nix { };
 }

--- a/tests/sanitize-package-names.nix
+++ b/tests/sanitize-package-names.nix
@@ -1,0 +1,39 @@
+{ testLib, npmlock2nix, lib }:
+let
+  i = npmlock2nix.internal;
+in
+testLib.runTests (
+  ({
+    # Using only a-zA-Z0-9 and a few selected special chars is allowed.
+    testIsValidDrvNameCharHappyPath = {
+      expr = i.isValidDrvNameChar "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890_-.?=";
+      expected = true;
+    };
+
+  }) // (
+    # build a set of tests, one for each of the characters that should be rejected
+    # The test results will help with debugging and look like this in case they fail:
+    #
+    #  FAIL: testIsValidDrvNameCharRejects: "-"
+    #  expected: false
+    #       got: true
+    let
+      cases = [ "!" "%" "^" "/" "\\" "#" "*" "(" ")" "@" "\"" "'" ];
+      mkCase = case: { expr = i.isValidDrvNameChar case; expected = false; };
+    in
+    lib.mapAttrs' (key: value: lib.nameValuePair "testIsValidDrvNameCharRejects: \"${key}\"" value) (
+      lib.genAttrs cases mkCase
+    )
+  ) // (
+    # Test that paths are being sanitized by our makeValidDrvName function.
+    # We map the test cases from a (input, output)-style attribute set into the test structure such that we will receive human-friendly error messages when the tests fail.
+    let
+      cases = {
+        "asdf-123.-?_" = "asdf-123.-?_";
+        "ABCDEF$!%^/\\#*()@-'" = "ABCDEF???????????-?";
+      };
+      mkCase = (input: expected: { inherit expected; expr = i.makeValidDrvName input; });
+    in
+    lib.mapAttrs' (input: expected: lib.nameValuePair "testMakeValidDrvName: \"${input}\"" (mkCase input expected)) cases
+  )
+)


### PR DESCRIPTION
For example a namespaced npm package will be `@org/name` and converted
to `?org?name`.

Fixes #48