### PR TITLE
node_modules: support entries that have URLs as versions

### DIFF
--- a/tests/default.nix
+++ b/tests/default.nix
@@ -10,6 +10,7 @@ in
   build-tests = callPackage ./build-tests.nix { };
   integration-tests = callPackage ./integration-tests { };
   make-github-source = callPackage ./make-github-source.nix { };
+  make-source = callPackage ./make-source.nix { };
   make-source-urls = callPackage ./make-source-urls.nix { };
   node-modules = callPackage ./node-modules.nix { };
   parse-github-ref = callPackage ./parse-github-ref.nix { };

--- a/tests/examples-projects/url-as-version/package-lock.json
+++ b/tests/examples-projects/url-as-version/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "url-as-version",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@matrix-org/olm": {
+      "version": "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.4.tgz",
+      "integrity": "sha512-ddaXWILlm1U0Z9qpcZffJjBFZRpz/GxQ1n/Qth3xKvYRUbniuPOgftNTDaxkEC4h04uJG5Ls/OdI1YJUyfuRzQ=="
+    }
+  }
+}

--- a/tests/examples-projects/url-as-version/package.json
+++ b/tests/examples-projects/url-as-version/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "url-as-version",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@matrix-org/olm": "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.4.tgz"
+  }
+}

--- a/tests/make-source.nix
+++ b/tests/make-source.nix
@@ -1,0 +1,33 @@
+{ testLib, npmlock2nix }:
+let
+  i = npmlock2nix.internal;
+  f = builtins.throw "Shouldn't be called";
+in
+testLib.runTests {
+  testMakeSourceRegular = {
+    expr = i.makeSource f "regular" {
+      resolved = "https://example.com/package.tgz";
+      integrity = "sha1-hrGk3k+s4YCsVFqD8VA1I9j+0RU=";
+    };
+    expected = {
+      integrity = "sha1-hrGk3k+s4YCsVFqD8VA1I9j+0RU=";
+      resolved = "file:///nix/store/rm32fd9z9snwr3i1v0gv6f5fh4abzqf3-package.tgz";
+    };
+  };
+
+  testMakeSourceUrlFromVersion =
+    let
+      version = "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.4.tgz";
+    in
+    {
+      expr = i.makeSource f "url-from-version" {
+        integrity = "sha512-ddaXWILlm1U0Z9qpcZffJjBFZRpz/GxQ1n/Qth3xKvYRUbniuPOgftNTDaxkEC4h04uJG5Ls/OdI1YJUyfuRzQ==";
+        inherit version;
+      };
+      expected = {
+        integrity = "sha512-ddaXWILlm1U0Z9qpcZffJjBFZRpz/GxQ1n/Qth3xKvYRUbniuPOgftNTDaxkEC4h04uJG5Ls/OdI1YJUyfuRzQ==";
+        resolved = "file:///nix/store/qn1b7cpsw383kprpzvq4r1x3yis9bczn-olm-3.2.4.tgz";
+        inherit version;
+      };
+    };
+}

--- a/tests/node-modules.nix
+++ b/tests/node-modules.nix
@@ -126,4 +126,15 @@ testLib.runTests {
     }).passthru.test-param;
     expected = 123;
   };
+
+  testVersionAsResolvedUrl =
+    let
+      drv = npmlock2nix.node_modules {
+        src = ./examples-projects/url-as-version;
+      };
+    in
+    {
+      expr = builtins.pathExists drv.outPath;
+      expected = true;
+    };
 }


### PR DESCRIPTION
In some cases a developer might pin a package to a specific URL in the
package.json. In that case the lockfile will not contain a resolved
key for the dependency but will have the original URL in the lockfile's
version field which we should use in that case.

With this patch I was able to build `Cinny` (a matrix client) on
revision 39b84a083d002deaa8f86689f97dbb887c27ffc0.